### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,3 +6,4 @@ sentence=Implement methods for the use of desklab (www.desk-lab.de) devices.
 paragraph=Supports desklab Photometers. You will also have to install Adafruit_SSD1306 and Adafruit-GFX-Library.
 category=Sensors
 url=https://github.com/desklab/desklab-arduino-lib
+depends=Adafruit_SSD1306, Adafruit GFX Library


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format